### PR TITLE
add monitors placeholder in nsFastJson object

### DIFF
--- a/src/ns2FastParams.ts
+++ b/src/ns2FastParams.ts
@@ -31,7 +31,8 @@ export function
             protocol: nsApp.protocol,
             virtual_address: nsApp.ipAddress,
             virtual_port: nsApp.port === '*' ? '0' : nsApp.port,
-            pool_members: []
+            pool_members: [],
+            monitors: []
         };
 
         if (nsApp?.opts?.['-persistenceType']) {


### PR DESCRIPTION
A possible fix for [issue 36](https://github.com/f5devcentral/vscode-f5-flipper/issues/36) to prevent crash and allow parsing (or partial parsing) of monitors. Added missing add monitors placeholder in nsFastJson object.
